### PR TITLE
Added keyboardShouldPersistTaps parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,7 @@ You can find another example in the /examples directory.
 | itemContent       | func   | node         | Y        | The item content with any elements you would like to include. Expects a function that returns a React element. Shown in examples above.        |
 | onItemPressed     | func   | (item) => {} | N        | Called when an item is pressed.                                                                                                                |
 | onLastItemPressed | func   | (item) => {} | N        | Called when an item without children is pressed.                                                                                               |
-| keyboardShouldPersistTaps | string   | 'handled' | N        | Determines when the keyboard should stay visible after a tap.
-                                                                                               |
+| keyboardShouldPersistTaps | string   | 'handled' | N        | Determines when the keyboard should stay visible after a tap.                                                                                        |
 | opacity           | number | 0.2          | N        | Defines the opacity of an item on click. Accept values from 0.0 to 1.0 (see [TouchableOpacity](https://reactnative.dev/docs/touchableopacity)) |
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ You can find another example in the /examples directory.
 | itemContent       | func   | node         | Y        | The item content with any elements you would like to include. Expects a function that returns a React element. Shown in examples above.        |
 | onItemPressed     | func   | (item) => {} | N        | Called when an item is pressed.                                                                                                                |
 | onLastItemPressed | func   | (item) => {} | N        | Called when an item without children is pressed.                                                                                               |
+| keyboardShouldPersistTaps | string   | 'handled' | N        | Determines when the keyboard should stay visible after a tap.
+                                                                                               |
 | opacity           | number | 0.2          | N        | Defines the opacity of an item on click. Accept values from 0.0 to 1.0 (see [TouchableOpacity](https://reactnative.dev/docs/touchableopacity)) |
 
 ## Acknowledgements

--- a/src/NestedList.js
+++ b/src/NestedList.js
@@ -13,6 +13,7 @@ export default function NestedList({
   onItemPressed = (item) => {},
   onLastItemPressed = (item) => {},
   itemKey,
+  keyboardShouldPersistTaps = "handled",
 }) {
   const [activeSections, setActiveSections] = useState([]);
 
@@ -65,6 +66,7 @@ export default function NestedList({
             itemContent={itemContent}
             opacity={opacity}
             itemKey={itemKey}
+            keyboardShouldPersistTaps={keyboardShouldPersistTaps},
           />
         </View>
       )}

--- a/src/NestedListView.js
+++ b/src/NestedListView.js
@@ -10,6 +10,7 @@ export default function NestedListView({
   itemContent,
   opacity,
   itemKey,
+  keyboardShouldPersistTaps,
 }) {
   const renderItem = (item) => (
     <NestedListItem
@@ -25,6 +26,9 @@ export default function NestedListView({
   );
 
   return (
-    <ScrollView>{items && items.map((item) => renderItem(item))}</ScrollView>
+    <ScrollView
+      keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+    >
+    {items && items.map((item) => renderItem(item))}</ScrollView>
   );
 }


### PR DESCRIPTION
Added `keyboardShouldPersistTaps` to control when the keyboard should stay visible after a tap in `ScrollView`

Available values for `keyboardShouldPersistTaps`:
`'never'` tapping outside of the focused text input when the keyboard is up dismisses the keyboard. When this happens, children won't receive the tap.
`'always'`, the keyboard will not dismiss automatically, and the scroll view will not catch taps, but children of the scroll view can catch taps.
`'handled'`, the keyboard will not dismiss automatically when the tap was handled by children of the scroll view (or captured by an ancestor).

Official Docs link: https://reactnative.dev/docs/scrollview